### PR TITLE
Auth verification of Dialogflow requests

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6,9 +6,19 @@ const { dialogflow, SignIn } = require("actions-on-google");
 const { i18next, initLocale } = require("./i18n");
 const config = functions.config().dialogflow || require("./config");
 
-// Set dialogflow client ID
+// Build auth header
+const usernameAndPassword = `${config.auth.user}:${config.auth.password}`;
+const base64Auth = Buffer.from(usernameAndPassword, "ascii").toString("base64");
+const authHeader = `Basic ${base64Auth}`;
+
+// Set dialogflow client ID and verification
 const app = dialogflow({
-  clientId: config.clientid
+  clientId: config.clientid,
+  verification: {
+    headers: {
+      authorization: authHeader
+    }
+  }
 });
 
 // Initialize localization module


### PR DESCRIPTION
This PR adds an additional layer of security to the API, so that only requests originating from the associated Dialogflow will go through.

Note: actions-on-google already verify if a request originates from a registered user, so this is just out of an abundance of caution :)

WARNING: Only merge when version 15 or higher is live. Older versions don't send basic auth headers