### PR TITLE
Make routines link dynamic

### DIFF
--- a/packages/webapp/src/components/ns-modal-saved.vue
+++ b/packages/webapp/src/components/ns-modal-saved.vue
@@ -61,7 +61,11 @@
             <i18next path="index.settings.hint">
               <a
                 target="_blank"
-                href="https://support.google.com/googlehome/answer/7029585?co=GENIE.Platform%3DAndroid&hl=en"
+                v-bind:href="
+                  `https://support.google.com/googlehome/answer/7029585?co=GENIE.Platform%3DAndroid&hl=${
+                    this.$i18n.i18next.language
+                  }`
+                "
                 >{{ $t("index.settings.hint-routines") }}</a
               >
               <br />


### PR DESCRIPTION
The "routines" link displayed in the settings-saved dialog always points to the English page.  
This PR makes the link dynamic so that it loads the page in the language selected by the user.

Related issue: #105 